### PR TITLE
Add skill points, extra filler/trap items, and bug fixes around egg count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,4 @@ FodyWeavers.xsd
 *.sln.iml
 /apworld/spyro3.apworld
 /apworld.zip
+*.apworld

--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,5 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+/apworld/spyro3.apworld
+/apworld.zip

--- a/apworld/spyro3/Items.py
+++ b/apworld/spyro3/Items.py
@@ -69,10 +69,21 @@ _all_items = [Spyro3ItemData(row[0], row[1], row[2]) for row in [
     
     ("Egg", 1000, Spyro3ItemCategory.EGG),
     ("Extra Life", 1001, Spyro3ItemCategory.MISC),
-    ("Lag Trap", 1002, Spyro3ItemCategory.TRAP),
-    ("Big Head Mode", 1003, Spyro3ItemCategory.TRAP),
-    ("Turn Spyro Yellow", 1004, Spyro3ItemCategory.MISC),
-    
+    ("Filler", 1002, Spyro3ItemCategory.MISC),
+    ("Lag Trap", 1003, Spyro3ItemCategory.TRAP),
+    ("Damage Sparx Trap", 1004, Spyro3ItemCategory.TRAP),
+    ("Sparxless Trap", 1005, Spyro3ItemCategory.TRAP),
+    ("Invincibility (15 seconds)", 1006, Spyro3ItemCategory.MISC),
+    ("Invincibility (30 seconds)", 1007, Spyro3ItemCategory.MISC),
+    ("Turn Spyro Red", 1008, Spyro3ItemCategory.MISC),
+    ("Turn Spyro Blue", 1009, Spyro3ItemCategory.MISC),
+    ("Turn Spyro Pink", 1010, Spyro3ItemCategory.MISC),
+    ("Turn Spyro Yellow", 1011, Spyro3ItemCategory.MISC),
+    ("Turn Spyro Green", 1012, Spyro3ItemCategory.MISC),
+    ("Turn Spyro Black", 1013, Spyro3ItemCategory.MISC),
+    ("Big Head Mode", 1014, Spyro3ItemCategory.MISC),
+    ("Flat Spyro Mode", 1015, Spyro3ItemCategory.MISC),
+    ("(Over)heal Sparx", 1016, Spyro3ItemCategory.MISC),
 ]]
 
 item_descriptions = {
@@ -80,7 +91,7 @@ item_descriptions = {
 
 item_dictionary = {item_data.name: item_data for item_data in _all_items}
 
-def BuildItemPool(multiworld, count, options):
+def BuildItemPool(multiworld, count, eggsToPlace, options):
     item_pool = []
     included_itemcount = 0
 
@@ -90,14 +101,52 @@ def BuildItemPool(multiworld, count, options):
             item_pool.append(item)
             included_itemcount = included_itemcount + 1
     remaining_count = count - included_itemcount
-    for i in range(150):
+    for i in range(eggsToPlace):
         item_pool.append(item_dictionary["Egg"])
-    remaining_count = remaining_count - 150
-    
-    allowed_items = [item for item in _all_items if item.category not in [Spyro3ItemCategory.EVENT, Spyro3ItemCategory.TRAP, Spyro3ItemCategory.EGG]]
+    remaining_count = remaining_count - eggsToPlace
+
+    # TODO: Determine fallback cases
+    #if remaining_count > 0 and not options.enable_filler_extra_lives and not options.enable_filler_invincibility and not options.enable_filler_color_change:
+    #    print("No filler items are enabled, but filler checks are present.  Defaulting to extra lives.")
+    #    options.enable_filler_extra_lives = 1
+
+    # Build a weighted list of allowed filler items.  Make changing Spyro's color in general the same weight as other items.
+    allowed_filler_items = []
+    allowed_misc_items = []
+    allowed_trap_items = []
+
+    for item in _all_items:
+        if item.name == 'Extra Life' and options.enable_filler_extra_lives:
+            for i in range(0, 6):
+                allowed_misc_items.append(item)
+        elif item.name.startswith('Invincibility (') and options.enable_filler_invincibility:
+            for i in range(0, 3):
+                allowed_misc_items.append(item)
+        elif item.name.startswith('Turn Spyro ') and options.enable_filler_color_change:
+            allowed_misc_items.append(item)
+        elif (item.name == 'Big Head Mode' or item.name == 'Flat Spyro Mode') and options.enable_filler_big_head_mode:
+            for i in range(0, 3):
+                allowed_misc_items.append(item)
+        elif item.name == '(Over)heal Sparx' and options.enable_filler_heal_sparx:
+            for i in range(0, 6):
+                allowed_misc_items.append(item)
+        elif item.name == 'Damage Sparx Trap' and options.enable_trap_damage_sparx:
+            allowed_trap_items.append(item)
+        elif item.name == 'Sparxless Trap' and options.enable_trap_sparxless:
+            allowed_trap_items.append(item)
+
+    # Get the correct blend of traps and filler items.
+    for i in range((100 - options.trap_filler_percent) * 50):
+        itemList = [item for item in allowed_misc_items]
+        item = multiworld.random.choice(itemList)
+        allowed_filler_items.append(item)
+    for i in range(options.trap_filler_percent * 50):
+        itemList = [item for item in allowed_trap_items]
+        item = multiworld.random.choice(itemList)
+        allowed_filler_items.append(item)
       
     for i in range(remaining_count):
-        itemList = [item for item in allowed_items]
+        itemList = [item for item in allowed_filler_items]
         item = multiworld.random.choice(itemList)
         item_pool.append(item)
     

--- a/apworld/spyro3/Items.py
+++ b/apworld/spyro3/Items.py
@@ -8,7 +8,8 @@ class Spyro3ItemCategory(IntEnum):
     SKIP = 1,
     EVENT = 2,
     MISC = 3,
-    TRAP = 4
+    TRAP = 4,
+    MISCEVENT = 5
 
 
 class Spyro3ItemData(NamedTuple):
@@ -38,7 +39,7 @@ _all_items = [Spyro3ItemData(row[0], row[1], row[2]) for row in [
     ("Seashell Shore Complete", 2003, Spyro3ItemCategory.EVENT),
     ("Sheila's Alp Complete", 2004, Spyro3ItemCategory.EVENT),
     ("Buzz Defeated", 2005, Spyro3ItemCategory.EVENT),
-    ("Crawdad Farm Complete", 2006, Spyro3ItemCategory.EVENT),
+    ("Crawdad Farm Complete", 2006, Spyro3ItemCategory.MISCEVENT),
     
     ("Icy Peak Complete", 2007, Spyro3ItemCategory.EVENT),
     ("Enchanted Towers Complete", 2008, Spyro3ItemCategory.EVENT),
@@ -46,7 +47,7 @@ _all_items = [Spyro3ItemData(row[0], row[1], row[2]) for row in [
     ("Bamboo Terrace Complete", 2010, Spyro3ItemCategory.EVENT),
     ("Sgt. Byrd's Base Complete", 2011, Spyro3ItemCategory.EVENT),
     ("Spike Defeated", 2012, Spyro3ItemCategory.EVENT),
-    ("Spider Town Complete", 2013, Spyro3ItemCategory.EVENT),
+    ("Spider Town Complete", 2013, Spyro3ItemCategory.MISCEVENT),
     
     ("Frozen Altars Complete", 2014, Spyro3ItemCategory.EVENT),
     ("Lost Fleet Complete", 2015, Spyro3ItemCategory.EVENT),
@@ -54,16 +55,16 @@ _all_items = [Spyro3ItemData(row[0], row[1], row[2]) for row in [
     ("Charmed Ridge Complete", 2017, Spyro3ItemCategory.EVENT),
     ("Bentley's Outpost Complete", 2018, Spyro3ItemCategory.EVENT),
     ("Scorch Defeated", 2019, Spyro3ItemCategory.EVENT),
-    ("Starfish Reef Complete", 2020, Spyro3ItemCategory.EVENT),
+    ("Starfish Reef Complete", 2020, Spyro3ItemCategory.MISCEVENT),
     
-    ("Crystal Islands Complete", 2021, Spyro3ItemCategory.EVENT),
-    ("Desert Ruins Complete", 2022, Spyro3ItemCategory.EVENT),
-    ("Haunted Tomb Complete", 2023, Spyro3ItemCategory.EVENT),
-    ("Dino Mines Complete", 2024, Spyro3ItemCategory.EVENT),
+    ("Crystal Islands Complete", 2021, Spyro3ItemCategory.MISCEVENT),
+    ("Desert Ruins Complete", 2022, Spyro3ItemCategory.MISCEVENT),
+    ("Haunted Tomb Complete", 2023, Spyro3ItemCategory.MISCEVENT),
+    ("Dino Mines Complete", 2024, Spyro3ItemCategory.MISCEVENT),
     ("Agent 9's Lab Complete", 2025, Spyro3ItemCategory.EVENT),
     ("Sorceress Defeated", 2026, Spyro3ItemCategory.EVENT),
-    ("Bugbot Factory Complete", 2027, Spyro3ItemCategory.EVENT),
-    ("Super Bonus Round Complete", 2028, Spyro3ItemCategory.EVENT),
+    ("Bugbot Factory Complete", 2027, Spyro3ItemCategory.MISCEVENT),
+    ("Super Bonus Round Complete", 2028, Spyro3ItemCategory.MISCEVENT),
     
     
     ("Egg", 1000, Spyro3ItemCategory.EGG),
@@ -91,7 +92,7 @@ def BuildItemPool(multiworld, count, options):
         item_pool.append(item_dictionary["Egg"])
     remaining_count = remaining_count - 150
     
-    allowed_items = [item for item in _all_items if item.category not in [Spyro3ItemCategory.EVENT, Spyro3ItemCategory.TRAP, Spyro3ItemCategory.EGG]]
+    allowed_items = [item for item in _all_items if item.category not in [Spyro3ItemCategory.MISCEVENT, Spyro3ItemCategory.EVENT, Spyro3ItemCategory.TRAP, Spyro3ItemCategory.EGG]]
       
     for i in range(remaining_count):
         itemList = [item for item in allowed_items]

--- a/apworld/spyro3/Items.py
+++ b/apworld/spyro3/Items.py
@@ -8,8 +8,7 @@ class Spyro3ItemCategory(IntEnum):
     SKIP = 1,
     EVENT = 2,
     MISC = 3,
-    TRAP = 4,
-    MISCEVENT = 5
+    TRAP = 4
 
 
 class Spyro3ItemData(NamedTuple):
@@ -39,7 +38,7 @@ _all_items = [Spyro3ItemData(row[0], row[1], row[2]) for row in [
     ("Seashell Shore Complete", 2003, Spyro3ItemCategory.EVENT),
     ("Sheila's Alp Complete", 2004, Spyro3ItemCategory.EVENT),
     ("Buzz Defeated", 2005, Spyro3ItemCategory.EVENT),
-    ("Crawdad Farm Complete", 2006, Spyro3ItemCategory.MISCEVENT),
+    ("Crawdad Farm Complete", 2006, Spyro3ItemCategory.EVENT),
     
     ("Icy Peak Complete", 2007, Spyro3ItemCategory.EVENT),
     ("Enchanted Towers Complete", 2008, Spyro3ItemCategory.EVENT),
@@ -47,7 +46,7 @@ _all_items = [Spyro3ItemData(row[0], row[1], row[2]) for row in [
     ("Bamboo Terrace Complete", 2010, Spyro3ItemCategory.EVENT),
     ("Sgt. Byrd's Base Complete", 2011, Spyro3ItemCategory.EVENT),
     ("Spike Defeated", 2012, Spyro3ItemCategory.EVENT),
-    ("Spider Town Complete", 2013, Spyro3ItemCategory.MISCEVENT),
+    ("Spider Town Complete", 2013, Spyro3ItemCategory.EVENT),
     
     ("Frozen Altars Complete", 2014, Spyro3ItemCategory.EVENT),
     ("Lost Fleet Complete", 2015, Spyro3ItemCategory.EVENT),
@@ -55,21 +54,24 @@ _all_items = [Spyro3ItemData(row[0], row[1], row[2]) for row in [
     ("Charmed Ridge Complete", 2017, Spyro3ItemCategory.EVENT),
     ("Bentley's Outpost Complete", 2018, Spyro3ItemCategory.EVENT),
     ("Scorch Defeated", 2019, Spyro3ItemCategory.EVENT),
-    ("Starfish Reef Complete", 2020, Spyro3ItemCategory.MISCEVENT),
+    ("Starfish Reef Complete", 2020, Spyro3ItemCategory.EVENT),
     
-    ("Crystal Islands Complete", 2021, Spyro3ItemCategory.MISCEVENT),
-    ("Desert Ruins Complete", 2022, Spyro3ItemCategory.MISCEVENT),
-    ("Haunted Tomb Complete", 2023, Spyro3ItemCategory.MISCEVENT),
-    ("Dino Mines Complete", 2024, Spyro3ItemCategory.MISCEVENT),
+    ("Crystal Islands Complete", 2021, Spyro3ItemCategory.EVENT),
+    ("Desert Ruins Complete", 2022, Spyro3ItemCategory.EVENT),
+    ("Haunted Tomb Complete", 2023, Spyro3ItemCategory.EVENT),
+    ("Dino Mines Complete", 2024, Spyro3ItemCategory.EVENT),
     ("Agent 9's Lab Complete", 2025, Spyro3ItemCategory.EVENT),
     ("Sorceress Defeated", 2026, Spyro3ItemCategory.EVENT),
-    ("Bugbot Factory Complete", 2027, Spyro3ItemCategory.MISCEVENT),
-    ("Super Bonus Round Complete", 2028, Spyro3ItemCategory.MISCEVENT),
+    ("Bugbot Factory Complete", 2027, Spyro3ItemCategory.EVENT),
+    ("Super Bonus Round Complete", 2028, Spyro3ItemCategory.EVENT),
+    ("Moneybags Chase Complete", 2029, Spyro3ItemCategory.EVENT),
     
     
     ("Egg", 1000, Spyro3ItemCategory.EGG),
     ("Extra Life", 1001, Spyro3ItemCategory.MISC),
     ("Lag Trap", 1002, Spyro3ItemCategory.TRAP),
+    ("Big Head Mode", 1003, Spyro3ItemCategory.TRAP),
+    ("Turn Spyro Yellow", 1004, Spyro3ItemCategory.MISC),
     
 ]]
 
@@ -92,7 +94,7 @@ def BuildItemPool(multiworld, count, options):
         item_pool.append(item_dictionary["Egg"])
     remaining_count = remaining_count - 150
     
-    allowed_items = [item for item in _all_items if item.category not in [Spyro3ItemCategory.MISCEVENT, Spyro3ItemCategory.EVENT, Spyro3ItemCategory.TRAP, Spyro3ItemCategory.EGG]]
+    allowed_items = [item for item in _all_items if item.category not in [Spyro3ItemCategory.EVENT, Spyro3ItemCategory.TRAP, Spyro3ItemCategory.EGG]]
       
     for i in range(remaining_count):
         itemList = [item for item in allowed_items]

--- a/apworld/spyro3/Items.py
+++ b/apworld/spyro3/Items.py
@@ -1,3 +1,4 @@
+import random
 from enum import IntEnum
 from typing import NamedTuple
 from BaseClasses import Item
@@ -136,17 +137,11 @@ def BuildItemPool(multiworld, count, eggsToPlace, options):
             allowed_trap_items.append(item)
 
     # Get the correct blend of traps and filler items.
-    for i in range((100 - options.trap_filler_percent) * 50):
-        itemList = [item for item in allowed_misc_items]
-        item = multiworld.random.choice(itemList)
-        allowed_filler_items.append(item)
-    for i in range(options.trap_filler_percent * 50):
-        itemList = [item for item in allowed_trap_items]
-        item = multiworld.random.choice(itemList)
-        allowed_filler_items.append(item)
-      
     for i in range(remaining_count):
-        itemList = [item for item in allowed_filler_items]
+        if random.random() * 100 < options.trap_filler_percent:
+            itemList = [item for item in allowed_trap_items]
+        else:
+            itemList = [item for item in allowed_misc_items]
         item = multiworld.random.choice(itemList)
         item_pool.append(item)
     

--- a/apworld/spyro3/Locations.py
+++ b/apworld/spyro3/Locations.py
@@ -8,7 +8,8 @@ class Spyro3LocationCategory(IntEnum):
     EGG = 0,
     SKIP = 1,
     EVENT = 2,
-    GEM = 3
+    GEM = 3,
+    SKILLPOINT = 4,
 
 
 class Spyro3LocationData(NamedTuple):
@@ -69,18 +70,19 @@ location_tables = {
     Spyro3LocationData(f"Sunrise Spring Home: Fly through the cave. (Ami)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunrise Spring Home: Bottom of the lake. (Bruce)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunrise Spring Home: Head bash the rock. (Liam)",f"Egg",Spyro3LocationCategory.EGG),
-    # TODO: Change to Junk and handle in Items.BuildItemPool instead
-    Spyro3LocationData(f"Sunrise Spring: All Gems", f"Turn Spyro Yellow", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Sunrise Spring: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Sunny Villa": [
     Spyro3LocationData(f"Sunny Villa: Rescue the mayor. (Sanders)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunny Villa: Hop to Rapunzel. (Lucy)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunny Villa: Lizard skating I. (Emily)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunny Villa: Lizard skating II. (Daisy)",f"Egg",Spyro3LocationCategory.EGG),
-    Spyro3LocationData(f"Sunny Villa: Egg by the building. (Vanessa)",f"Egg",Spyro3LocationCategory.EGG),
+    Spyro3LocationData(f"Sunny Villa: Egg by the building. (Vanessa)",f"Filler",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunny Villa: Glide to the spring. (Miles)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Sunny Villa Complete", "Sunny Villa Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Sunny Villa: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData("Sunny Villa: All Gems", "Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Sunny Villa: Flame all trees (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
+    Spyro3LocationData(f"Sunny Villa: Skateboard course record I (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Cloud Spires": [
     Spyro3LocationData(f"Cloud Spires: Turn on the cloud generator. (Henry)",f"Egg",Spyro3LocationCategory.EGG),
@@ -90,7 +92,7 @@ location_tables = {
     Spyro3LocationData(f"Cloud Spires: Run along the wall. (Stephanie)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Cloud Spires: Glide to the island. (Clare)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Cloud Spires Complete", "Cloud Spires Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Cloud Spires: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Cloud Spires: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Molten Crater": [
     Spyro3LocationData(f"Molten Crater: Get to the tiki lodge. (Curlie)",f"Egg",Spyro3LocationCategory.EGG),
@@ -100,7 +102,9 @@ location_tables = {
     Spyro3LocationData(f"Molten Crater: Sgt. Byrd blows up a wall. (Luna)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Molten Crater: Egg by lava river. (Rikki)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Molten Crater Complete", "Molten Crater Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Molten Crater: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Molten Crater: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Molten Crater: Assemble tiki heads (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
+    Spyro3LocationData(f"Molten Crater: Supercharge the wall (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Seashell Shore": [
     Spyro3LocationData(f"Seashell Shore: Free the seals. (Dizzy)",f"Egg",Spyro3LocationCategory.EGG),
@@ -110,20 +114,21 @@ location_tables = {
     Spyro3LocationData(f"Seashell Shore: Clear out the pipe. (Duke)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Seashell Shore: Hop to the secret cave. (Jared)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Seashell Shore Complete", "Seashell Shore Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Seashell Shore: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Seashell Shore: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Seashell Shore: Catch the funky chicken (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Mushroom Speedway": [
     Spyro3LocationData(f"Mushroom Speedway: Time attack. (Sabina)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Mushroom Speedway: Race the butterflies. (John)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Mushroom Speedway: Hunter's dogfight. (Tater)",f"Egg",Spyro3LocationCategory.EGG),
-    Spyro3LocationData(f"Mushroom Speedway: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Mushroom Speedway: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Sheila's Alp": [
     Spyro3LocationData(f"Sheila's Alp: Help Bobby get home. (Nan)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sheila's Alp: Help Pete get home. (Jenny)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sheila's Alp: Help Billy get home. (Ruby)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Sheila's Alp Complete", "Sheila's Alp Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Sheila's Alp: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Sheila's Alp: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Buzz": [
     Spyro3LocationData(f"Buzz's Dungeon: Defeat Buzz. (Grayson)",f"Egg",Spyro3LocationCategory.EGG),
@@ -132,7 +137,7 @@ location_tables = {
 "Crawdad Farm": [
     Spyro3LocationData(f"Crawdad Farm: Take Sparx to the farm. (Nora)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Crawdad Farm Complete", "Crawdad Farm Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Crawdad Farm: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Crawdad Farm: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 #Homeworld 2
 "Midday Garden": [
@@ -141,7 +146,7 @@ location_tables = {
     Spyro3LocationData(f"Midday Gardens Home: Catch the thief. (Trixie)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Midday Gardens Home: Superflame the flowerpots. (Matt)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Midday Gardens Home: Climb to the ledge. (Modesty)",f"Egg",Spyro3LocationCategory.EGG),
-    Spyro3LocationData(f"Midday Gardens: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Midday Gardens: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Icy Peak": [
     Spyro3LocationData(f"Icy Peak: Find Doug the polar bear. (Chet)",f"Egg",Spyro3LocationCategory.EGG),
@@ -151,7 +156,8 @@ location_tables = {
     Spyro3LocationData(f"Icy Peak: On top of a ledge. (Maynard)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Icy Peak: Glide to the sky island. (Reez)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Icy Peak Complete", "Icy Peak Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Icy Peak: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Icy Peak: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Icy Peak: Glide to pedestal (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Enchanted Towers": [
     Spyro3LocationData(f"Enchanted Towers: Destroy the sorceress statue. (Peanut)",f"Egg",Spyro3LocationCategory.EGG),
@@ -161,7 +167,8 @@ location_tables = {
     Spyro3LocationData(f"Enchanted Towers: Trick skater II. (Alex)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Enchanted Towers: Glide to the small island. (Gladys)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Enchanted Towers Complete", "Enchanted Towers Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Enchanted Towers: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Enchanted Towers: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Enchanted Towers: Skateboard course record II (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Spooky Swamp": [
     Spyro3LocationData(f"Spooky Swamp: Find Shiny the firefly. (Thelonious)",f"Egg",Spyro3LocationCategory.EGG),
@@ -171,7 +178,8 @@ location_tables = {
     Spyro3LocationData(f"Spooky Swamp: Escort the twins II. (Michele)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Spooky Swamp: Defeat sleepy head. (Herbi)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Spooky Swamp Complete", "Spooky Swamp Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Spooky Swamp: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Spooky Swamp: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Spooky Swamp: Destroy all piranha signs (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Bamboo Terrace": [
     Spyro3LocationData(f"Bamboo Terrace: Clear the pandas' path. (Tom)",f"Egg",Spyro3LocationCategory.EGG),
@@ -181,20 +189,21 @@ location_tables = {
     Spyro3LocationData(f"Bamboo Terrace: Glide to the small island. (Dwight)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Bamboo Terrace: Catch the thief. (Pee-wee)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Bamboo Terrace Complete", "Bamboo Terrace Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Bamboo Terrace: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Bamboo Terrace: All Gems", f"Filler", Spyro3LocationCategory.GEM),
 ],
 "Country Speedway": [
     Spyro3LocationData(f"Country Speedway: Time attack. (Gavin)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Country Speedway: Race the pigs. (Shemp)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Country Speedway: Hunter's rescue mission. (Roberto)",f"Egg",Spyro3LocationCategory.EGG),
-    Spyro3LocationData(f"Country Speedway: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Country Speedway: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Sgt. Byrd's Base": [
     Spyro3LocationData(f"Sgt. Byrd's Base: Clear the building. (RyanLee)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sgt. Byrd's Base: Clear the caves. (Sigfried)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sgt. Byrd's Base: Rescue 5 hummingbirds. (Roy)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Sgt. Byrd's Base Complete", "Sgt. Byrd's Base Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Sgt. Byrd's Base: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Sgt. Byrd's Base: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Sgt. Byrd's Base: Bomb the gophers (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Spike": [
     Spyro3LocationData(f"Spike's Arena: Defeat Spike. (Monique)",f"Egg",Spyro3LocationCategory.EGG),
@@ -203,7 +212,7 @@ location_tables = {
 "Spider Town": [
     Spyro3LocationData(f"Spider Town: Go to town. (Tootie)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Spider Town Complete", "Spider Town Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Spider Town: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Spider Town: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 #Homeworld 3
 "Evening Lake": [
@@ -212,7 +221,7 @@ location_tables = {
     Spyro3LocationData(f"Evening Lake Home: Break the tower wall. (Stooby)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Evening Lake Home: Belly of the whale. (Jonah)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Evening Lake Home: I'm invincible! (Stuart)",f"Egg",Spyro3LocationCategory.EGG),
-    Spyro3LocationData(f"Evening Lake: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Evening Lake: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Frozen Altars": [
     Spyro3LocationData(f"Frozen Altars: Melt the snowmen. (Jana)",f"Egg",Spyro3LocationCategory.EGG),
@@ -222,7 +231,8 @@ location_tables = {
     Spyro3LocationData(f"Frozen Altars: Glide from the temple roof. (Cecil)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Frozen Altars: Across the rooftops. (Jasper)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Frozen Altars Complete", "Frozen Altars Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Frozen Altars: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Frozen Altars: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Frozen Altars: Beat yeti in two rounds (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Lost Fleet": [
     Spyro3LocationData(f"Lost Fleet: Find Crazy Ed's treasure. (Craig)",f"Egg",Spyro3LocationCategory.EGG),
@@ -232,7 +242,8 @@ location_tables = {
     Spyro3LocationData(f"Lost Fleet: Skate race the rhynocs. (Oliver)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Lost Fleet: Skate race Hunter. (Aiden)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Lost Fleet Complete", "Lost Fleet Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Lost Fleet: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Lost Fleet: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Lost Fleet: Skateboard record time (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Fireworks Factory": [
     Spyro3LocationData(f"Fireworks Factory: Destwoy the wocket! (Grady)",f"Egg",Spyro3LocationCategory.EGG),
@@ -242,7 +253,8 @@ location_tables = {
     Spyro3LocationData(f"Fireworks Factory: Bad dragon! (Evan)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Fireworks Factory: Hidden in an alcove. (Noodles)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Fireworks Factory Complete", "Fireworks Factory Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Fireworks Factory: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Fireworks Factory: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Fireworks Factory: Find Agent 9's powerup (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Charmed Ridge": [
     Spyro3LocationData(f"Charmed Ridge: Rescue the Fairy Princess. (Sakura)",f"Egg",Spyro3LocationCategory.EGG),
@@ -252,20 +264,23 @@ location_tables = {
     Spyro3LocationData(f"Charmed Ridge: Jack and the beanstalk I. (Shelley)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Charmed Ridge: Jack and the beanstalk II. (Chuck)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Charmed Ridge Complete", "Charmed Ridge Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Charmed Ridge: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Charmed Ridge: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Charmed Ridge: The Impossible Tower (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
+    Spyro3LocationData(f"Charmed Ridge: Shoot the temple windows (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Honey Speedway": [
     Spyro3LocationData(f"Honey Speedway: Time attack. (Chris)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Honey Speedway: Race the bees (Henri)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Honey Speedway: Hunter's narrow escape. (Nori)",f"Egg",Spyro3LocationCategory.EGG),
-    Spyro3LocationData(f"Honey Speedway: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Honey Speedway: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Bentley's Outpost": [
     Spyro3LocationData(f"Bentley's Outpost: Help Bartholomew home. (Eric)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Bentley's Outpost: The Gong Show (Brian)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Bentley's Outpost: Snowball's chance. (Charlie)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Bentley's Outpost Complete", "Bentley's Outpost Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Bentley's Outpost: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Bentley's Outpost: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Bentley's Outpost: Push box off the cliff (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Scorch": [
     Spyro3LocationData(f"Scorch's Pit: Defeat Scorch. (James)",f"Egg",Spyro3LocationCategory.EGG),
@@ -274,7 +289,7 @@ location_tables = {
 "Starfish Reef": [
     Spyro3LocationData(f"Starfish Reef: Beach party! (Ahnashawn)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Starfish Reef Complete", "Starfish Reef Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Starfish Reef: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Starfish Reef: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 #Homeworld 4
 "Midnight Mountain": [
@@ -285,7 +300,7 @@ location_tables = {
     Spyro3LocationData(f"Midnight Mountain Home: Stomp the floor. (Buddy)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Midnight Mountain Home: Egg for sale. (Al)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Midnight Mountain Home: Moneybags Chase Complete", "Moneybags Chase Complete",Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Midnight Mountain: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Midnight Mountain: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Crystal Islands": [
     Spyro3LocationData(f"Crystal Islands: Reach the crystal tower. (Lloyd)",f"Egg",Spyro3LocationCategory.EGG),
@@ -295,7 +310,7 @@ location_tables = {
     Spyro3LocationData(f"Crystal Islands: Glide to the island. (Manie)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Crystal Islands: Catch the flying thief. (Max)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Crystal Islands Complete", "Crystal Islands Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Crystal Islands: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Crystal Islands: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Desert Ruins": [
     Spyro3LocationData(f"Desert Ruins: Raid the tomb. (Marty)",f"Egg",Spyro3LocationCategory.EGG),
@@ -305,7 +320,8 @@ location_tables = {
     Spyro3LocationData(f"Desert Ruins: Sink or singe. (Nelly)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Desert Ruins: Give me a hand (Andy)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Desert Ruins Complete", "Desert Ruins Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Desert Ruins: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Desert Ruins: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Desert Ruins: Destroy all seaweed (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Haunted Tomb": [
     Spyro3LocationData(f"Haunted Tomb: Release the temple dweller. (Will)",f"Egg",Spyro3LocationCategory.EGG),
@@ -315,7 +331,8 @@ location_tables = {
     Spyro3LocationData(f"Haunted Tomb: Clear the caves. (Roxy)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Haunted Tomb: Climb the wall. (Christine)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Haunted Tomb Complete", "Haunted Tomb Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Haunted Tomb: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Haunted Tomb: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Haunted Tomb: Swim into the dark hole (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Dino Mines": [
     Spyro3LocationData(f"Dino Mines: Jail break! (Kiki)",f"Egg",Spyro3LocationCategory.EGG),
@@ -325,20 +342,23 @@ location_tables = {
     Spyro3LocationData(f"Dino Mines: Leap of faith. (Dan)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Dino Mines: Take it to the bank. (Sergio)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Dino Mines Complete", "Dino Mines Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Dino Mines: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Dino Mines: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Dino Mines: Hit all the seahorses (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
+    Spyro3LocationData(f"Dino Mines: Hit the secret dino (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Harbor Speedway": [
     Spyro3LocationData(f"Harbor Speedway: Time attack. (Kobe)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Harbor Speedway: Race the blue footed boobies. (Jessie)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Harbor Speedway: Hunter's pursuit. (Sara)",f"Egg",Spyro3LocationCategory.EGG),
-    Spyro3LocationData(f"Harbor Speedway: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Harbor Speedway: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Agent 9's Lab": [
     Spyro3LocationData(f"Agent 9's Lab: Blast and bomb the rhynocs. (Rowan)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Agent 9's Lab: Snipe the boats (Tony)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Agent 9's Lab: This place has gone to the birds. (Beulah)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Agent 9's Lab Complete", "Agent 9's Lab Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Agent 9's Lab: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Agent 9's Lab: All Gems", f"Filler", Spyro3LocationCategory.GEM),
+    Spyro3LocationData(f"Agent 9's Lab: Blow up all palm trees (Skill Point)", f"Filler", Spyro3LocationCategory.SKILLPOINT),
 ],
 "Sorceress": [
     Spyro3LocationData(f"Sorceress's Lair: Defeat the Sorceress? (George)",f"Egg",Spyro3LocationCategory.EGG),
@@ -347,12 +367,12 @@ location_tables = {
 "Bugbot Factory": [
     Spyro3LocationData(f"Bugbot Factory: Shut down the factory. (Anabelle)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Bugbot Factory Complete", "Bugbot Factory Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Bugbot Factory: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Bugbot Factory: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 "Super Bonus Round": [
     Spyro3LocationData(f"Super Bonus Round: Woo, a secret egg. (Yin Yang)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Super Bonus Round Complete", "Super Bonus Round Complete", Spyro3LocationCategory.EVENT),
-    Spyro3LocationData(f"Super Bonus Round: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    Spyro3LocationData(f"Super Bonus Round: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ]
 
 }

--- a/apworld/spyro3/Locations.py
+++ b/apworld/spyro3/Locations.py
@@ -33,6 +33,7 @@ class Spyro3Location(Location):
         super().__init__(player, name, address, parent)
         self.default_item_name = default_item_name
         self.category = category
+        self.name = name
 
     @staticmethod
     def get_name_to_id() -> dict:

--- a/apworld/spyro3/Locations.py
+++ b/apworld/spyro3/Locations.py
@@ -77,7 +77,7 @@ location_tables = {
     Spyro3LocationData(f"Sunny Villa: Hop to Rapunzel. (Lucy)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunny Villa: Lizard skating I. (Emily)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunny Villa: Lizard skating II. (Daisy)",f"Egg",Spyro3LocationCategory.EGG),
-    Spyro3LocationData(f"Sunny Villa: Egg by the building. (Vanessa)",f"Filler",Spyro3LocationCategory.EGG),
+    Spyro3LocationData(f"Sunny Villa: Egg by the building. (Vanessa)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunny Villa: Glide to the spring. (Miles)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData("Sunny Villa Complete", "Sunny Villa Complete", Spyro3LocationCategory.EVENT),
     Spyro3LocationData("Sunny Villa: All Gems", "Filler", Spyro3LocationCategory.GEM),

--- a/apworld/spyro3/Locations.py
+++ b/apworld/spyro3/Locations.py
@@ -42,8 +42,8 @@ class Spyro3Location(Location):
         table_offset = 1000
 
         table_order = [
-            "Sunrise Springs","Sunny Villa","Cloud Spires","Molten Crater","Seashell Shore","Mushroom Speedway","Sheila's Alp", "Buzz", "Crawdad Farm",
-            "Midday Garden","Icy Peak","Enchanted Towers","Spooky Swamp","Bamboo Terrace","Country Speedway","Sgt. Byrd's Base","Spike","Spider Town",
+            "Sunrise Spring","Sunny Villa","Cloud Spires","Molten Crater","Seashell Shore","Mushroom Speedway","Sheila's Alp", "Buzz", "Crawdad Farm",
+            "Midday Gardens","Icy Peak","Enchanted Towers","Spooky Swamp","Bamboo Terrace","Country Speedway","Sgt. Byrd's Base","Spike","Spider Town",
             "Evening Lake","Frozen Altars","Lost Fleet","Fireworks Factory","Charmed Ridge","Honey Speedway","Bentley's Outpost","Scorch","Starfish Reef",
             "Midnight Mountain","Crystal Islands","Desert Ruins","Haunted Tomb","Dino Mines","Harbor Speedway","Agent 9's Lab","Sorceress","Bugbot Factory","Super Bonus Round"
         ]
@@ -64,7 +64,7 @@ class Spyro3Location(Location):
 
 location_tables = {
 #Homeworld 1
-"Sunrise Springs": [
+"Sunrise Spring": [
     Spyro3LocationData(f"Sunrise Spring Home: Learn gliding. (Coltrane)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunrise Spring Home: Egg by the stream. (Isabelle)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunrise Spring Home: Fly through the cave. (Ami)",f"Egg",Spyro3LocationCategory.EGG),
@@ -140,7 +140,7 @@ location_tables = {
     Spyro3LocationData(f"Crawdad Farm: All Gems", f"Filler", Spyro3LocationCategory.GEM)
 ],
 #Homeworld 2
-"Midday Garden": [
+"Midday Gardens": [
     Spyro3LocationData(f"Midday Gardens Home: Underwater egg. (Dave)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Midday Gardens Home: Secret ice cave. (Mingus)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Midday Gardens Home: Catch the thief. (Trixie)",f"Egg",Spyro3LocationCategory.EGG),

--- a/apworld/spyro3/Locations.py
+++ b/apworld/spyro3/Locations.py
@@ -69,7 +69,8 @@ location_tables = {
     Spyro3LocationData(f"Sunrise Spring Home: Fly through the cave. (Ami)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunrise Spring Home: Bottom of the lake. (Bruce)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Sunrise Spring Home: Head bash the rock. (Liam)",f"Egg",Spyro3LocationCategory.EGG),
-    Spyro3LocationData(f"Sunrise Spring: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
+    # TODO: Change to Junk and handle in Items.BuildItemPool instead
+    Spyro3LocationData(f"Sunrise Spring: All Gems", f"Turn Spyro Yellow", Spyro3LocationCategory.GEM)
 ],
 "Sunny Villa": [
     Spyro3LocationData(f"Sunny Villa: Rescue the mayor. (Sanders)",f"Egg",Spyro3LocationCategory.EGG),
@@ -283,6 +284,7 @@ location_tables = {
     Spyro3LocationData(f"Midnight Mountain Home: Glide to the island. (Saki)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Midnight Mountain Home: Stomp the floor. (Buddy)",f"Egg",Spyro3LocationCategory.EGG),
     Spyro3LocationData(f"Midnight Mountain Home: Egg for sale. (Al)",f"Egg",Spyro3LocationCategory.EGG),
+    Spyro3LocationData(f"Midnight Mountain Home: Moneybags Chase Complete", "Moneybags Chase Complete",Spyro3LocationCategory.EVENT),
     Spyro3LocationData(f"Midnight Mountain: All Gems", f"Extra Life", Spyro3LocationCategory.GEM)
 ],
 "Crystal Islands": [

--- a/apworld/spyro3/Options.py
+++ b/apworld/spyro3/Options.py
@@ -15,6 +15,45 @@ class EnableGemChecksOption(Toggle):
     """Adds checks for getting all gems in a level"""
     display_name = "Enable Gem Checks"
 
+class EnableSkillpointChecksOptions(Toggle):
+    """Adds checks for getting skill points"""
+    display_name = "Enable Skillpoint Checks"
+
+class EnableFillerExtraLives(DefaultOnToggle):
+    """Allows filler items to include extra lives"""
+    display_name = "Enable Extra Lives Filler"
+
+class EnableFillerInvincibility(Toggle):
+    """Allows filler items to include temporary invincibility"""
+    display_name = "Enable Temporary Invincibility Filler"
+
+class EnableFillerColorChange(Toggle):
+    """Allows filler items to include changing Spyro's color"""
+    display_name = "Enable Changing Spyro's Color Filler"
+
+class EnableFillerBigHeadMode(Toggle):
+    """Allows filler items to include turning on Big Head Mode and Flat Spyro Mode"""
+    display_name = "Enable Big Head and Flat Spyro Filler"
+
+class EnableFillerHealSparx(Toggle):
+    """Allows filler items to include healing Sparx. Can exceed max health."""
+    display_name = "Enable (over)healing Sparx Filler"
+
+class TrapFillerPercent(Range):
+    """Determines the percentage of filler items that will be traps."""
+    display_name = "Trap Percentage of Filler"
+    range_start = 0
+    range_end = 100
+    default = 0
+
+class EnableTrapDamageSparx(Toggle):
+    """Allows filler items to include damaging Sparx. Cannot directly kill Spyro."""
+    display_name = "Enable Hurting Sparx Trap"
+
+class EnableTrapSparxless(Toggle):
+    """Allows filler items to include removing Sparx."""
+    display_name = "Enable Sparxless Trap"
+
 class GoalOption(Choice):
     """Lets the user choose the completion goal
     Sorceress 1 - Beat the sorceress and obtain 100 eggs
@@ -32,3 +71,12 @@ class Spyro3Option(PerGameCommonOptions):
     goal: GoalOption
     guaranteed_items: GuaranteedItemsOption
     enable_gem_checks: EnableGemChecksOption
+    enable_skillpoint_checks: EnableSkillpointChecksOptions
+    enable_filler_extra_lives: EnableFillerExtraLives
+    enable_filler_invincibility: EnableFillerInvincibility
+    enable_filler_color_change: EnableFillerColorChange
+    enable_filler_big_head_mode: EnableFillerBigHeadMode
+    enable_filler_heal_sparx: EnableFillerHealSparx
+    trap_filler_percent: TrapFillerPercent
+    enable_trap_damage_sparx: EnableTrapDamageSparx
+    enable_trap_sparxless: EnableTrapSparxless

--- a/apworld/spyro3/Options.py
+++ b/apworld/spyro3/Options.py
@@ -5,7 +5,8 @@ from Options import Toggle, DefaultOnToggle, Option, Range, Choice, ItemDict, De
 SORCERESS_ONE = 0
 EGG_FOR_SALE = 1
 SORCERESS_TWO = 2
-SUNNY_VILLA = 3
+# Test goal for ease of debugging
+#SUNNY_VILLA = 3
 
 class GuaranteedItemsOption(ItemDict):
     """Guarantees that the specified items will be in the item pool"""
@@ -64,7 +65,8 @@ class GoalOption(Choice):
     option_sorceress_1 = SORCERESS_ONE
     option_egg_for_sale = EGG_FOR_SALE
     option_sorceress_2 = SORCERESS_TWO
-    option_sunny_villa = SUNNY_VILLA
+    # Test goal for ease of debugging
+    #option_sunny_villa = SUNNY_VILLA
 
 @dataclass
 class Spyro3Option(PerGameCommonOptions):

--- a/apworld/spyro3/Options.py
+++ b/apworld/spyro3/Options.py
@@ -2,7 +2,10 @@ import typing
 from dataclasses import dataclass
 from Options import Toggle, DefaultOnToggle, Option, Range, Choice, ItemDict, DeathLink, PerGameCommonOptions
 
-
+SORCERESS_ONE = 0
+EGG_FOR_SALE = 1
+SORCERESS_TWO = 2
+SUNNY_VILLA = 3
 
 class GuaranteedItemsOption(ItemDict):
     """Guarantees that the specified items will be in the item pool"""
@@ -15,12 +18,14 @@ class EnableGemChecksOption(Toggle):
 class GoalOption(Choice):
     """Lets the user choose the completion goal
     Sorceress 1 - Beat the sorceress and obtain 100 eggs
+    Egg For Sale - Chase Moneybags after defeating the sorceress the first time.
     Sorceress 2 - Beat the sorceress a second time"""
     display_name = "Completion Goal"
-    default = 0
-    option_sorceress_1 = 0
-    option_sunny_villa = 1
-    option_sorceress_2 = 2
+    default = SORCERESS_ONE
+    option_sorceress_1 = SORCERESS_ONE
+    option_egg_for_sale = EGG_FOR_SALE
+    option_sorceress_2 = SORCERESS_TWO
+    option_sunny_villa = SUNNY_VILLA
 
 @dataclass
 class Spyro3Option(PerGameCommonOptions):

--- a/apworld/spyro3/Options.py
+++ b/apworld/spyro3/Options.py
@@ -12,8 +12,18 @@ class EnableGemChecksOption(Toggle):
     """Adds checks for getting all gems in a level"""
     display_name = "Enable Gem Checks"
 
+class GoalOption(Choice):
+    """Lets the user choose the completion goal
+    Sorceress 1 - Beat the sorceress and obtain 100 eggs
+    Sorceress 2 - Beat the sorceress a second time"""
+    display_name = "Completion Goal"
+    default = 0
+    option_sorceress_1 = 0
+    option_sunny_villa = 1
+    option_sorceress_2 = 2
+
 @dataclass
 class Spyro3Option(PerGameCommonOptions):
-    #goal: GoalOption
+    goal: GoalOption
     guaranteed_items: GuaranteedItemsOption
     enable_gem_checks: EnableGemChecksOption

--- a/apworld/spyro3/__init__.py
+++ b/apworld/spyro3/__init__.py
@@ -5,7 +5,7 @@ from BaseClasses import MultiWorld, Region, Item, Entrance, Tutorial, ItemClassi
 from Options import Toggle
 
 from worlds.AutoWorld import World, WebWorld
-from worlds.generic.Rules import set_rule, add_rule, add_item_rule
+from worlds.generic.Rules import set_rule, add_rule, add_item_rule, forbid_item
 
 from .Items import Spyro3Item, Spyro3ItemCategory, item_dictionary, key_item_names, item_descriptions, BuildItemPool
 from .Locations import Spyro3Location, Spyro3LocationCategory, location_tables, location_dictionary
@@ -192,11 +192,11 @@ class Spyro3World(World):
 
         #removable_items = [item for item in itempool if item.classification != ItemClassification.progression]
         #print("marked " + str(len(removable_items)) + " items as removable")
-        
-        for item in itempool:
-            #print("removable item: " + item.name)
-            itempool.remove(item)
-            itempool.append(self.create_item(foo.pop().name))
+
+        #for item in itempool:
+        #    print("removable item: " + item.name)
+        #    #itempool.remove(item)
+        #    new_itempool.append(self.create_item(foo.pop().name))
 
         # Add regular items to itempool
         self.multiworld.itempool += itempool
@@ -211,7 +211,7 @@ class Spyro3World(World):
         
         #print("Final Item pool: ")
         #for item in self.multiworld.itempool:
-            #print(item.name)
+        #    print(item.name)
 
 
     def create_item(self, name: str) -> Item:
@@ -249,7 +249,12 @@ class Spyro3World(World):
         for region in self.multiworld.get_regions(self.player):
             for location in region.locations:
                     set_rule(location, lambda state: True)
-        self.multiworld.completion_condition[self.player] = lambda state:  is_boss_defeated(self,"Sorceress", state) and state.has("Egg", self.player, 100)
+        if self.options.goal.value == 0:
+            self.multiworld.completion_condition[self.player] = lambda state: is_boss_defeated(self,"Sorceress", state) and state.has("Egg", self.player, 100)
+        elif self.options.goal.value == 1:
+            self.multiworld.completion_condition[self.player] = lambda state: state.has("Sunny Villa Complete", self.player)
+        else:
+            self.multiworld.completion_condition[self.player] = lambda state: state.has("Super Bonus Round Complete", self.player)
         
         set_rule(self.multiworld.get_location("Sunny Villa: All Gems", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         set_rule(self.multiworld.get_location("Sunny Villa: Hop to Rapunzel. (Lucy)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
@@ -270,15 +275,12 @@ class Spyro3World(World):
                 is_level_completed(self,"Cloud Spires", state) and \
                 is_level_completed(self,"Molten Crater", state) and \
                 is_level_completed(self,"Seashell Shore", state) and \
-                is_level_completed(self,"Sheila's Alp", state) and \
-                state.has("Egg", self.player, 15))       
+                is_level_completed(self,"Sheila's Alp", state))
 
-        set_indirect_rule(self, "Crawdad Farm", lambda state: is_boss_defeated(self,"Buzz", state) and state.has("Egg", self.player, 16)) 
+        set_indirect_rule(self, "Crawdad Farm", lambda state: is_boss_defeated(self,"Buzz", state))
 
         set_indirect_rule(self, "Midday Garden", lambda state: is_boss_defeated(self,"Buzz", state))      
-                  
-        set_indirect_rule(self, "Icy Peak", lambda state: state.has("Egg", self.player,16))
-        set_indirect_rule(self, "Enchanted Towers", lambda state: state.has("Egg", self.player,16))
+
         set_rule(self.multiworld.get_location("Enchanted Towers: All Gems", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state))
         set_rule(self.multiworld.get_location("Enchanted Towers: Collect the bones. (Ralph)", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state))        
         
@@ -292,56 +294,58 @@ class Spyro3World(World):
         set_rule(self.multiworld.get_location("Bamboo Terrace: Smash to the mountain top. (Brubeck)", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
         
         set_indirect_rule(self, "Country Speedway", lambda state: state.has("Egg", self.player,36))
-        set_indirect_rule(self, "Sgt. Byrd's Base", lambda state: state.has("Egg", self.player,16))               
 
         set_indirect_rule(self, "Spike", lambda state: is_level_completed(self,"Icy Peak", state) and \
                 is_level_completed(self,"Enchanted Towers", state) and \
                 is_level_completed(self,"Spooky Swamp", state) and \
                 is_level_completed(self,"Bamboo Terrace", state) and \
-                is_level_completed(self,"Sgt. Byrd's Base", state) and \
-                state.has("Egg", self.player,31))
+                is_level_completed(self,"Sgt. Byrd's Base", state))
         
-        set_indirect_rule(self, "Spider Town", lambda state: is_boss_defeated(self,"Spike", state) and state.has("Egg", self.player,32))
+        set_indirect_rule(self, "Spider Town", lambda state: is_boss_defeated(self,"Spike", state))
         set_indirect_rule(self, "Evening Lake", lambda state: is_boss_defeated(self,"Spike", state))     
 
-        set_indirect_rule(self, "Frozen Altars", lambda state: state.has("Egg", self.player,32))
-        set_rule(self.multiworld.get_location("Frozen Altars: All Gems", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
         set_rule(self.multiworld.get_location("Frozen Altars: Box the yeti. (Aly)", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
         set_rule(self.multiworld.get_location("Frozen Altars: Box the yeti again! (Ricco)", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state) and state.can_reach_location("Frozen Altars: Box the yeti. (Aly)", self.player))
-        set_indirect_rule(self, "Lost Fleet", lambda state: state.has("Egg", self.player,32))
         set_indirect_rule(self, "Fireworks Factory", lambda state: state.has("Egg", self.player,50))
         set_rule(self.multiworld.get_location("Fireworks Factory: All Gems", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
         set_rule(self.multiworld.get_location("Fireworks Factory: You're doomed! (Patty)", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
         set_rule(self.multiworld.get_location("Fireworks Factory: You're still doomed! (Donovan)", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state) and state.can_reach_location("Fireworks Factory: You're doomed! (Patty)", self.player))
         
         set_indirect_rule(self, "Charmed Ridge", lambda state: state.has("Egg", self.player,58))
-        set_rule(self.multiworld.get_location("Charmed Ridge: All Gems", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state))
         set_rule(self.multiworld.get_location("Charmed Ridge: Cat witch chaos. (Abby)", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state))
         
         set_indirect_rule(self, "Honey Speedway", lambda state: state.has("Egg", self.player,65))
-        set_indirect_rule(self, "Bentley's Outpost", lambda state: state.has("Egg", self.player,32))
 
         set_indirect_rule(self, "Scorch", lambda state: is_level_completed(self,"Frozen Altars", state) and \
                 is_level_completed(self,"Lost Fleet", state) and \
                 is_level_completed(self,"Fireworks Factory", state) and \
                 is_level_completed(self,"Charmed Ridge", state) and \
-                is_level_completed(self,"Bentley's Outpost", state) and \
-                state.has("Egg", self.player,60))
-        
-        set_indirect_rule(self, "Starfish Reef", lambda state: is_boss_defeated(self,"Scorch", state) and state.has("Egg", self.player,61)) 
+                is_level_completed(self,"Bentley's Outpost", state))
+
+        # After completing 3 levels in Evening Lake, the player is unable to complete any Hunter challenges until defeating Scorch.
+        # To prevent the player from locking themselves out of progression, these must be logically locked behind Scorch.
+        # Note: The egg "Sunrise Spring Home: Learn Gliding (Coltrane)" is not affected by this - Hunter remains in Sunrise Spring home.
+        set_rule(self.multiworld.get_location("Sunny Villa: Lizard skating I. (Emily)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+        set_rule(self.multiworld.get_location("Sunny Villa: Lizard skating II. (Daisy)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+        set_rule(self.multiworld.get_location("Mushroom Speedway: Hunter's dogfight. (Tater)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+        set_rule(self.multiworld.get_location("Enchanted Towers: Trick skater I. (Caroline)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+        set_rule(self.multiworld.get_location("Enchanted Towers: Trick skater II. (Alex)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+        set_rule(self.multiworld.get_location("Country Speedway: Hunter's rescue mission. (Roberto)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+        set_rule(self.multiworld.get_location("Lost Fleet: Skate race the rhynocs. (Oliver)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+        set_rule(self.multiworld.get_location("Lost Fleet: Skate race Hunter. (Aiden)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+        set_rule(self.multiworld.get_location("Honey Speedway: Hunter's narrow escape. (Nori)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+
+        set_indirect_rule(self, "Starfish Reef", lambda state: is_boss_defeated(self,"Scorch", state))
         set_indirect_rule(self, "Midnight Mountain", lambda state: is_boss_defeated(self,"Scorch", state))
         set_rule(self.multiworld.get_location("Midnight Mountain Home: Egg for sale. (Al)", self.player), lambda state: is_boss_defeated(self,"Sorceress", state))
 
-        set_indirect_rule(self, "Crystal Islands", lambda state: state.has("Egg", self.player,61))
         set_rule(self.multiworld.get_location("Crystal Islands: All Gems", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
         set_rule(self.multiworld.get_location("Crystal Islands: Whack a mole. (Hank)", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
-        
-        set_indirect_rule(self, "Desert Ruins", lambda state: state.has("Egg", self.player,61))
+
         set_rule(self.multiworld.get_location("Desert Ruins: All Gems", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         set_rule(self.multiworld.get_location("Desert Ruins: Krash Kangaroo I. (Lester)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         set_rule(self.multiworld.get_location("Desert Ruins: Krash Kangaroo II. (Pete)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         set_indirect_rule(self, "Haunted Tomb", lambda state: state.has("Egg", self.player,70))
-        set_rule(self.multiworld.get_location("Haunted Tomb: All Gems", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
         set_rule(self.multiworld.get_location("Haunted Tomb: Clear the caves. (Roxy)", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
         set_indirect_rule(self, "Dino Mines", lambda state: state.has("Egg", self.player,80))
         set_rule(self.multiworld.get_location("Dino Mines: All Gems", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
@@ -349,17 +353,16 @@ class Spyro3World(World):
         set_rule(self.multiworld.get_location("Dino Mines: Take it to the bank. (Sergio)", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state) and state.can_reach_location("Dino Mines: Gunfight at the Jurassic Corral. (Sharon)", self.player))
         
         set_indirect_rule(self, "Harbor Speedway", lambda state: state.has("Egg", self.player,90))
-        set_indirect_rule(self, "Agent 9's Lab", lambda state: state.has("Egg", self.player,61))
 
-        set_indirect_rule(self, "Sorceress", lambda state: is_level_completed(self,"Crystal Islands", state) and \
-                is_level_completed(self,"Desert Ruins", state) and \
-                is_level_completed(self,"Haunted Tomb", state) and \
-                is_level_completed(self,"Dino Mines", state) and \
-                is_level_completed(self,"Agent 9's Lab", state) and \
-                state.has("Egg", self.player,100))
+        set_indirect_rule(self, "Sorceress", lambda state: state.has("Egg", self.player,100))
 
-        set_indirect_rule(self, "Bugbot Factory", lambda state: is_boss_defeated(self,"Sorceress", state) and state.has("Egg", self.player,100))
-        set_indirect_rule(self, "Super Bonus Round", lambda state: is_boss_defeated(self,"Sorceress", state) and state.has("Egg", self.player,149))           
+        set_indirect_rule(self, "Bugbot Factory", lambda state: is_boss_defeated(self,"Sorceress", state))
+        set_indirect_rule(self, "Super Bonus Round", lambda state: is_boss_defeated(self,"Sorceress", state) and state.has("Egg", self.player,149))
+
+        # Prevent multiple eggs from being placed in SBR.
+        # TODO: Make more robust and handle location accessibility settings.
+        if self.options.enable_gem_checks.value:
+            forbid_item(self.multiworld.get_location("Super Bonus Round: All Gems", self.player), "Egg", self.player)
                 
     def fill_slot_data(self) -> Dict[str, object]:
         slot_data: Dict[str, object] = {}
@@ -392,6 +395,7 @@ class Spyro3World(World):
 
         slot_data = {
             "options": {
+                "goal": self.options.goal.value,
                 "guaranteed_items": self.options.guaranteed_items.value,
                 "enable_gem_checks": self.options.enable_gem_checks.value
             },

--- a/apworld/spyro3/__init__.py
+++ b/apworld/spyro3/__init__.py
@@ -75,8 +75,8 @@ class Spyro3World(World):
         regions: Dict[str, Region] = {}
         regions["Menu"] = self.create_region("Menu", [])
         regions.update({region_name: self.create_region(region_name, location_tables[region_name]) for region_name in [
-            "Sunrise Springs","Sunny Villa","Cloud Spires","Molten Crater","Seashell Shore","Mushroom Speedway","Sheila's Alp", "Buzz", "Crawdad Farm",
-            "Midday Garden","Icy Peak","Enchanted Towers","Spooky Swamp","Bamboo Terrace","Country Speedway","Sgt. Byrd's Base","Spike","Spider Town",
+            "Sunrise Spring","Sunny Villa","Cloud Spires","Molten Crater","Seashell Shore","Mushroom Speedway","Sheila's Alp", "Buzz", "Crawdad Farm",
+            "Midday Gardens","Icy Peak","Enchanted Towers","Spooky Swamp","Bamboo Terrace","Country Speedway","Sgt. Byrd's Base","Spike","Spider Town",
             "Evening Lake","Frozen Altars","Lost Fleet","Fireworks Factory","Charmed Ridge","Honey Speedway","Bentley's Outpost","Scorch","Starfish Reef",
             "Midnight Mountain","Crystal Islands","Desert Ruins","Haunted Tomb","Dino Mines","Harbor Speedway","Agent 9's Lab","Sorceress","Bugbot Factory","Super Bonus Round"
         ]})
@@ -88,29 +88,29 @@ class Spyro3World(World):
             connection.connect(regions[to_region])
             #print(f"Connecting {from_region} to {to_region} Using entrance: " + connection.name)
             
-        create_connection("Menu", "Sunrise Springs")       
+        create_connection("Menu", "Sunrise Spring")
                 
-        create_connection("Sunrise Springs", "Sunny Villa")
-        create_connection("Sunrise Springs", "Cloud Spires")
-        create_connection("Sunrise Springs", "Molten Crater")
-        create_connection("Sunrise Springs", "Seashell Shore")
-        create_connection("Sunrise Springs", "Mushroom Speedway")
-        create_connection("Sunrise Springs", "Sheila's Alp")
+        create_connection("Sunrise Spring", "Sunny Villa")
+        create_connection("Sunrise Spring", "Cloud Spires")
+        create_connection("Sunrise Spring", "Molten Crater")
+        create_connection("Sunrise Spring", "Seashell Shore")
+        create_connection("Sunrise Spring", "Mushroom Speedway")
+        create_connection("Sunrise Spring", "Sheila's Alp")
              
-        create_connection("Sunrise Springs", "Buzz")
-        create_connection("Sunrise Springs", "Crawdad Farm")        
-        create_connection("Sunrise Springs", "Midday Garden")     
+        create_connection("Sunrise Spring", "Buzz")
+        create_connection("Sunrise Spring", "Crawdad Farm")
+        create_connection("Sunrise Spring", "Midday Gardens")
         
-        create_connection("Midday Garden", "Icy Peak")
-        create_connection("Midday Garden", "Enchanted Towers")
-        create_connection("Midday Garden", "Spooky Swamp")
-        create_connection("Midday Garden", "Bamboo Terrace")
-        create_connection("Midday Garden", "Country Speedway")
-        create_connection("Midday Garden", "Sgt. Byrd's Base")
+        create_connection("Midday Gardens", "Icy Peak")
+        create_connection("Midday Gardens", "Enchanted Towers")
+        create_connection("Midday Gardens", "Spooky Swamp")
+        create_connection("Midday Gardens", "Bamboo Terrace")
+        create_connection("Midday Gardens", "Country Speedway")
+        create_connection("Midday Gardens", "Sgt. Byrd's Base")
 
-        create_connection("Midday Garden", "Spike")
-        create_connection("Midday Garden", "Spider Town")        
-        create_connection("Midday Garden", "Evening Lake")   
+        create_connection("Midday Gardens", "Spike")
+        create_connection("Midday Gardens", "Spider Town")
+        create_connection("Midday Gardens", "Evening Lake")
         
         create_connection("Evening Lake", "Frozen Altars")
         create_connection("Evening Lake", "Lost Fleet")
@@ -151,8 +151,9 @@ class Spyro3World(World):
                     self.location_name_to_id[location.name],
                     new_region
                 )
-            else:
-                # Replace non-randomized progression items with events
+            elif location.category == Spyro3LocationCategory.EVENT:
+                # Remove non-randomized progression items as checks because of the use of a "filler" fake item.
+                # Replace events with event items for spoiler log readability.
                 event_item = self.create_item(location.default_item)
                 #if event_item.classification != ItemClassification.progression:
                 #    continue
@@ -183,7 +184,6 @@ class Spyro3World(World):
         
         #print("Creating items")
         for location in self.multiworld.get_locations(self.player):
-                # There is currently
                 #print("found item in category: " + str(location.category))
                 item_data = item_dictionary[location.default_item_name]
                 # There is a bug with the current client implementation where another player auto-collecting an item on the
@@ -274,14 +274,11 @@ class Spyro3World(World):
 
         set_rule(self.multiworld.get_location("Sunny Villa: Hop to Rapunzel. (Lucy)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         
-        set_indirect_rule(self, "Molten Crater", lambda state: state.has("Egg", self.player, 10))    
-        set_rule(self.multiworld.get_location("Molten Crater: All Gems", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state))
+        set_indirect_rule(self, "Molten Crater", lambda state: state.has("Egg", self.player, 10))
         set_rule(self.multiworld.get_location("Molten Crater: Replace idol heads. (Ryan)", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state))
         set_rule(self.multiworld.get_location("Molten Crater: Sgt. Byrd blows up a wall. (Luna)", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state))
-        set_rule(self.multiworld.get_location("Molten Crater: Assemble tiki heads (Skill Point)", self.player), lambda state: is_level_completed(self, "Sgt. Byrd's Base", state))
         
-        set_indirect_rule(self, "Seashell Shore", lambda state: state.has("Egg", self.player, 14))   
-        set_rule(self.multiworld.get_location("Seashell Shore: All Gems", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
+        set_indirect_rule(self, "Seashell Shore", lambda state: state.has("Egg", self.player, 14))
         set_rule(self.multiworld.get_location("Seashell Shore: Destroy the sand castle. (Mollie)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         set_rule(self.multiworld.get_location("Seashell Shore: Hop to the secret cave. (Jared)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         
@@ -295,17 +292,15 @@ class Spyro3World(World):
 
         set_indirect_rule(self, "Crawdad Farm", lambda state: is_boss_defeated(self,"Buzz", state))
 
-        set_indirect_rule(self, "Midday Garden", lambda state: is_boss_defeated(self,"Buzz", state))      
+        set_indirect_rule(self, "Midday Gardens", lambda state: is_boss_defeated(self,"Buzz", state))
 
         set_rule(self.multiworld.get_location("Enchanted Towers: Collect the bones. (Ralph)", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state))        
         
-        set_indirect_rule(self, "Spooky Swamp", lambda state: state.has("Egg", self.player,25))        
-        set_rule(self.multiworld.get_location("Spooky Swamp: All Gems", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
+        set_indirect_rule(self, "Spooky Swamp", lambda state: state.has("Egg", self.player,25))
         set_rule(self.multiworld.get_location("Spooky Swamp: Escort the twins I. (Peggy)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         set_rule(self.multiworld.get_location("Spooky Swamp: Escort the twins II. (Michele)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state) and state.can_reach_location("Spooky Swamp: Escort the twins I. (Peggy)", self.player))
 
         set_indirect_rule(self, "Bamboo Terrace", lambda state: state.has("Egg", self.player,30))
-        set_rule(self.multiworld.get_location("Bamboo Terrace: All Gems", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
         set_rule(self.multiworld.get_location("Bamboo Terrace: Smash to the mountain top. (Brubeck)", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
         
         set_indirect_rule(self, "Country Speedway", lambda state: state.has("Egg", self.player,36))
@@ -321,16 +316,12 @@ class Spyro3World(World):
 
         set_rule(self.multiworld.get_location("Frozen Altars: Box the yeti. (Aly)", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
         set_rule(self.multiworld.get_location("Frozen Altars: Box the yeti again! (Ricco)", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state) and state.can_reach_location("Frozen Altars: Box the yeti. (Aly)", self.player))
-        set_rule(self.multiworld.get_location("Frozen Altars: Beat yeti in two rounds (Skill Point)", self.player), lambda state: is_level_completed(self, "Bentley's Outpost", state) and state.can_reach_location("Frozen Altars: Box the yeti. (Aly)", self.player))
         set_indirect_rule(self, "Fireworks Factory", lambda state: state.has("Egg", self.player,50))
-        set_rule(self.multiworld.get_location("Fireworks Factory: All Gems", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
         set_rule(self.multiworld.get_location("Fireworks Factory: You're doomed! (Patty)", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
         set_rule(self.multiworld.get_location("Fireworks Factory: You're still doomed! (Donovan)", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state) and state.can_reach_location("Fireworks Factory: You're doomed! (Patty)", self.player))
-        set_rule(self.multiworld.get_location("Fireworks Factory: Find Agent 9's powerup (Skill Point)", self.player), lambda state: is_level_completed(self, "Agent 9's Lab", state))
 
         set_indirect_rule(self, "Charmed Ridge", lambda state: state.has("Egg", self.player,58))
         set_rule(self.multiworld.get_location("Charmed Ridge: Cat witch chaos. (Abby)", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state))
-        set_rule(self.multiworld.get_location("Charmed Ridge: Shoot the temple windows (Skill Point)", self.player), lambda state: is_level_completed(self, "Sgt. Byrd's Base", state))
         
         set_indirect_rule(self, "Honey Speedway", lambda state: state.has("Egg", self.player,65))
 
@@ -346,18 +337,12 @@ class Spyro3World(World):
         # Most, if not all gems, in skateboarding areas can be collected without the skateboard, but leave out of base logic.
         set_rule(self.multiworld.get_location("Sunny Villa: Lizard skating I. (Emily)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
         set_rule(self.multiworld.get_location("Sunny Villa: Lizard skating II. (Daisy)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
-        set_rule(self.multiworld.get_location("Sunny Villa: Skateboard course record I (Skill Point)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
-        set_rule(self.multiworld.get_location("Sunny Villa: All Gems", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state) and is_boss_defeated(self, "Scorch", state))
         set_rule(self.multiworld.get_location("Mushroom Speedway: Hunter's dogfight. (Tater)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
-        set_rule(self.multiworld.get_location("Enchanted Towers: All Gems", self.player), lambda state: is_level_completed(self,"Sgt. Byrd's Base", state) and is_boss_defeated(self, "Scorch", state))
         set_rule(self.multiworld.get_location("Enchanted Towers: Trick skater I. (Caroline)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
         set_rule(self.multiworld.get_location("Enchanted Towers: Trick skater II. (Alex)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
-        set_rule(self.multiworld.get_location("Enchanted Towers: Skateboard course record II (Skill Point)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
         set_rule(self.multiworld.get_location("Country Speedway: Hunter's rescue mission. (Roberto)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
         set_rule(self.multiworld.get_location("Lost Fleet: Skate race the rhynocs. (Oliver)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
         set_rule(self.multiworld.get_location("Lost Fleet: Skate race Hunter. (Aiden)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
-        set_rule(self.multiworld.get_location("Lost Fleet: All Gems", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
-        set_rule(self.multiworld.get_location("Lost Fleet: Skateboard record time (Skill Point)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
         set_rule(self.multiworld.get_location("Honey Speedway: Hunter's narrow escape. (Nori)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
 
         set_indirect_rule(self, "Starfish Reef", lambda state: is_boss_defeated(self,"Scorch", state))
@@ -365,17 +350,13 @@ class Spyro3World(World):
         set_rule(self.multiworld.get_location("Midnight Mountain Home: Egg for sale. (Al)", self.player), lambda state: is_boss_defeated(self,"Sorceress", state))
         set_rule(self.multiworld.get_location("Midnight Mountain Home: Moneybags Chase Complete", self.player), lambda state: is_boss_defeated(self, "Sorceress", state))
 
-        set_rule(self.multiworld.get_location("Crystal Islands: All Gems", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
         set_rule(self.multiworld.get_location("Crystal Islands: Whack a mole. (Hank)", self.player), lambda state: is_level_completed(self,"Bentley's Outpost", state))
 
-        set_rule(self.multiworld.get_location("Desert Ruins: All Gems", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         set_rule(self.multiworld.get_location("Desert Ruins: Krash Kangaroo I. (Lester)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         set_rule(self.multiworld.get_location("Desert Ruins: Krash Kangaroo II. (Pete)", self.player), lambda state: is_level_completed(self,"Sheila's Alp", state))
         set_indirect_rule(self, "Haunted Tomb", lambda state: state.has("Egg", self.player,70))
         set_rule(self.multiworld.get_location("Haunted Tomb: Clear the caves. (Roxy)", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
         set_indirect_rule(self, "Dino Mines", lambda state: state.has("Egg", self.player,80))
-        set_rule(self.multiworld.get_location("Dino Mines: All Gems", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
-        set_rule(self.multiworld.get_location("Dino Mines: Hit the secret dino (Skill Point)", self.player), lambda state: is_level_completed(self, "Agent 9's Lab", state))
         set_rule(self.multiworld.get_location("Dino Mines: Gunfight at the Jurassic Corral. (Sharon)", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state))
         set_rule(self.multiworld.get_location("Dino Mines: Take it to the bank. (Sergio)", self.player), lambda state: is_level_completed(self,"Agent 9's Lab", state) and state.can_reach_location("Dino Mines: Gunfight at the Jurassic Corral. (Sharon)", self.player))
         
@@ -385,6 +366,29 @@ class Spyro3World(World):
 
         set_indirect_rule(self, "Bugbot Factory", lambda state: is_boss_defeated(self,"Sorceress", state))
         set_indirect_rule(self, "Super Bonus Round", lambda state: is_boss_defeated(self,"Sorceress", state) and state.has("Egg", self.player,149))
+
+        if Spyro3LocationCategory.GEM in self.enabled_location_categories:
+            set_rule(self.multiworld.get_location("Molten Crater: All Gems", self.player), lambda state: is_level_completed(self, "Sgt. Byrd's Base", state))
+            set_rule(self.multiworld.get_location("Seashell Shore: All Gems", self.player), lambda state: is_level_completed(self, "Sheila's Alp", state))
+            set_rule(self.multiworld.get_location("Spooky Swamp: All Gems", self.player), lambda state: is_level_completed(self, "Sheila's Alp", state))
+            set_rule(self.multiworld.get_location("Bamboo Terrace: All Gems", self.player), lambda state: is_level_completed(self, "Bentley's Outpost", state))
+            set_rule(self.multiworld.get_location("Fireworks Factory: All Gems", self.player), lambda state: is_level_completed(self, "Agent 9's Lab", state))
+            set_rule(self.multiworld.get_location("Sunny Villa: All Gems", self.player), lambda state: is_level_completed(self, "Sheila's Alp", state) and is_boss_defeated(self, "Scorch", state))
+            set_rule(self.multiworld.get_location("Enchanted Towers: All Gems", self.player), lambda state: is_level_completed(self, "Sgt. Byrd's Base", state) and is_boss_defeated(self, "Scorch", state))
+            set_rule(self.multiworld.get_location("Lost Fleet: All Gems", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+            set_rule(self.multiworld.get_location("Crystal Islands: All Gems", self.player), lambda state: is_level_completed(self, "Bentley's Outpost", state))
+            set_rule(self.multiworld.get_location("Desert Ruins: All Gems", self.player), lambda state: is_level_completed(self, "Sheila's Alp", state))
+            set_rule(self.multiworld.get_location("Dino Mines: All Gems", self.player), lambda state: is_level_completed(self, "Agent 9's Lab", state))
+
+        if Spyro3LocationCategory.SKILLPOINT in self.enabled_location_categories:
+            set_rule(self.multiworld.get_location("Molten Crater: Assemble tiki heads (Skill Point)", self.player), lambda state: is_level_completed(self, "Sgt. Byrd's Base", state))
+            set_rule(self.multiworld.get_location("Frozen Altars: Beat yeti in two rounds (Skill Point)", self.player), lambda state: is_level_completed(self, "Bentley's Outpost", state) and state.can_reach_location("Frozen Altars: Box the yeti. (Aly)", self.player))
+            set_rule(self.multiworld.get_location("Fireworks Factory: Find Agent 9's powerup (Skill Point)", self.player), lambda state: is_level_completed(self, "Agent 9's Lab", state))
+            set_rule(self.multiworld.get_location("Charmed Ridge: Shoot the temple windows (Skill Point)", self.player), lambda state: is_level_completed(self, "Sgt. Byrd's Base", state))
+            set_rule(self.multiworld.get_location("Sunny Villa: Skateboard course record I (Skill Point)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+            set_rule(self.multiworld.get_location("Enchanted Towers: Skateboard course record II (Skill Point)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+            set_rule(self.multiworld.get_location("Lost Fleet: Skateboard record time (Skill Point)", self.player), lambda state: is_boss_defeated(self, "Scorch", state))
+            set_rule(self.multiworld.get_location("Dino Mines: Hit the secret dino (Skill Point)", self.player), lambda state: is_level_completed(self, "Agent 9's Lab", state))
                 
     def fill_slot_data(self) -> Dict[str, object]:
         slot_data: Dict[str, object] = {}

--- a/apworld/spyro3/__init__.py
+++ b/apworld/spyro3/__init__.py
@@ -15,7 +15,8 @@ from .Options import Spyro3Option
 SORCERESS_ONE = 0
 EGG_FOR_SALE = 1
 SORCERESS_TWO = 2
-SUNNY_VILLA = 3
+# Test goal for ease of debugging
+#SUNNY_VILLA = 3
 
 class Spyro3Web(WebWorld):
     bug_report_page = ""
@@ -193,8 +194,9 @@ class Spyro3World(World):
                         location.category in [Spyro3LocationCategory.EVENT] or \
                         (self.options.goal.value == SORCERESS_ONE and location.name == "Sorceress's Lair: Defeat the Sorceress? (George)") or \
                         (self.options.goal.value == EGG_FOR_SALE and location.name == "Midnight Mountain Home: Egg for sale. (Al)") or \
-                        (self.options.goal.value == SORCERESS_TWO and location.name == "Super Bonus Round: Woo, a secret egg. (Yin Yang)") or \
-                        (self.options.goal.value == SUNNY_VILLA and location.name == "Sunny Villa: Rescue the mayor. (Sanders)"):
+                        (self.options.goal.value == SORCERESS_TWO and location.name == "Super Bonus Round: Woo, a secret egg. (Yin Yang)"): #or \
+                        # Test goal for ease of debugging
+                        #(self.options.goal.value == SUNNY_VILLA and location.name == "Sunny Villa: Rescue the mayor. (Sanders)"):
                     #print(f"Adding vanilla item/event {location.default_item_name} to {location.name}")
                     item = self.create_item(location.default_item_name)
                     self.multiworld.get_location(location.name, self.player).place_locked_item(item)
@@ -232,6 +234,8 @@ class Spyro3World(World):
             item_classification = ItemClassification.progression
         elif item_dictionary[name].category in useful_categories:
             item_classification = ItemClassification.useful
+        elif item_dictionary[name].category == Spyro3ItemCategory.TRAP:
+            item_classification = ItemClassification.trap
         else:
             item_classification = ItemClassification.filler
 
@@ -260,8 +264,9 @@ class Spyro3World(World):
                     set_rule(location, lambda state: True)
         if self.options.goal.value == SORCERESS_TWO:
             self.multiworld.completion_condition[self.player] = lambda state: state.has("Super Bonus Round Complete", self.player)
-        elif self.options.goal.value == SUNNY_VILLA:
-            self.multiworld.completion_condition[self.player] = lambda state: state.has("Sunny Villa Complete", self.player)
+        # Test goal for ease of debugging
+        #elif self.options.goal.value == SUNNY_VILLA:
+        #    self.multiworld.completion_condition[self.player] = lambda state: state.has("Sunny Villa Complete", self.player)
         elif self.options.goal.value == EGG_FOR_SALE:
             self.multiworld.completion_condition[self.player] = lambda state: state.has("Moneybags Chase Complete", self.player)
         else:

--- a/source/Addresses.cs
+++ b/source/Addresses.cs
@@ -13,6 +13,7 @@ namespace S3AP
         public const uint IsInDemoMode = 0x0006c758;
         public const uint GameStatus = 0x0006e424;
         public const uint PlayerLives = 0x0006c864;
+        public const uint PlayerHealth = 0x00070688;
 
         public const uint SunriseSpringGems = 0x071af0;
         public const uint SunnyVillaGems = 0x071af4;
@@ -52,9 +53,11 @@ namespace S3AP
         public const uint BugbotFactoryGems = 0x071b7c;
         public const uint SuperBonusRoundGems = 0x071b80;
 
+        public const uint SkillPointAddress = 0x066ca0;
+
         public const uint BigHeadMode = 0x06fc76;
         public const uint SpyroWidth = 0x06fc79;
-        public const uint SpyroHeight = 0x06c7d;
+        public const uint SpyroHeight = 0x06fc7d;
         public const uint SpyroLength = 0x06fc81;
         public const uint SpyroColorAddress = 0x06fc84;
         public const short SpyroColorDefault = 0;
@@ -64,6 +67,7 @@ namespace S3AP
         public const short SpyroColorGreen = 4;
         public const short SpyroColorYellow = 5;
         public const short SpyroColorBlack = 6;
+        public const uint InvincibilityDurationAddress = 0x0705d4;
 
     }
 }

--- a/source/Addresses.cs
+++ b/source/Addresses.cs
@@ -12,6 +12,8 @@ namespace S3AP
         public const uint EggStartAddress = 0x000703E0;
         public const uint IsInDemoMode = 0x0006c758;
         public const uint GameStatus = 0x0006e424;
+        // The values at this and the following 3 bytes seem to be 0 only on reset.
+        public const uint ResetCheckAddress = 0x0006e434;
         public const uint PlayerLives = 0x0006c864;
         public const uint PlayerHealth = 0x00070688;
 

--- a/source/Addresses.cs
+++ b/source/Addresses.cs
@@ -52,6 +52,18 @@ namespace S3AP
         public const uint BugbotFactoryGems = 0x071b7c;
         public const uint SuperBonusRoundGems = 0x071b80;
 
+        public const uint BigHeadMode = 0x06fc76;
+        public const uint SpyroWidth = 0x06fc79;
+        public const uint SpyroHeight = 0x06c7d;
+        public const uint SpyroLength = 0x06fc81;
+        public const uint SpyroColorAddress = 0x06fc84;
+        public const short SpyroColorDefault = 0;
+        public const short SpyroColorRed = 1;
+        public const short SpyroColorBlue = 2;
+        public const short SpyroColorPink = 3;
+        public const short SpyroColorGreen = 4;
+        public const short SpyroColorYellow = 5;
+        public const short SpyroColorBlack = 6;
 
     }
 }

--- a/source/App.xaml.cs
+++ b/source/App.xaml.cs
@@ -83,8 +83,6 @@ namespace S3AP
 
         private async void ItemReceived(object? o, ItemReceivedEventArgs args)
         {
-            System.Diagnostics.Debug.WriteLine($"Item Received: {JsonConvert.SerializeObject(args.Item)}");
-            Log.Logger.Information($"Item Received: {JsonConvert.SerializeObject(args.Item)}");
             if (args.Item.Name == "Egg")
             {
                 var currentEggs = CalculateCurrentEggs();
@@ -165,7 +163,7 @@ namespace S3AP
         private static void CheckGoalCondition()
         {
             var currentEggs = CalculateCurrentEggs();
-            int goal = int.Parse(Client.Options?.GetValueOrDefault("goal").ToString());
+            int goal = int.Parse(Client.Options?.GetValueOrDefault("goal", 0).ToString());
             // TODO: Don't hard code IDs.
             if ((CompletionGoal)goal == CompletionGoal.Sorceress1)
             {
@@ -254,6 +252,11 @@ namespace S3AP
             {
                 LogHint(e.Message);
             }
+            else if (e.Message.Parts.Length == 1 && e.Message.Parts[0].Text == $"{Client.CurrentSession.Players.ActivePlayer.Name}: clearSpyroGameState")
+            {
+                Log.Logger.Information("Clearing the game state.  Please reconnect to the server while in game to refresh received items.");
+                Client.ForceReloadAllItems();
+            }
             Log.Logger.Information(JsonConvert.SerializeObject(e.Message));
         }
         private static void LogHint(LogMessage message)
@@ -286,8 +289,6 @@ namespace S3AP
         }
         private static int CalculateCurrentEggs()
         {
-            System.Diagnostics.Debug.WriteLine(Client.GameState?.ReceivedItems);
-            System.Diagnostics.Debug.WriteLine(Client.GameState?.ReceivedItems.Where(x => x.Name == "Egg").Count() ?? 0);
             var count = Client.GameState?.ReceivedItems.Where(x => x.Name == "Egg").Count() ?? 0;
             count = Math.Min(count, 150);
             Memory.WriteByte(Addresses.TotalEggAddress, (byte)(count));

--- a/source/App.xaml.cs
+++ b/source/App.xaml.cs
@@ -10,6 +10,7 @@ using Archipelago.MultiClient.Net.MessageLog.Messages;
 using Microsoft.Maui.Devices.Sensors;
 using Newtonsoft.Json;
 using Serilog;
+using static S3AP.Models.Enums;
 using Color = Microsoft.Maui.Graphics.Color;
 using Location = Archipelago.Core.Models.Location;
 
@@ -101,10 +102,29 @@ namespace S3AP
         private static void CheckGoalCondition()
         {
             var currentEggs = CalculateCurrentEggs();
-            if (currentEggs >= 100 && Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Name == "Sorceress Defeated"))
+            int goal = int.Parse(Client.Options.GetValueOrDefault("goal").ToString());
+            if ((CompletionGoal)goal == CompletionGoal.Sorceress1)
             {
-                Client.SendGoalCompletion();
+                if (currentEggs >= 100 && Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == 1264000))
+                {
+                    Client.SendGoalCompletion();
+                }
             }
+            else if ((CompletionGoal)goal == CompletionGoal.SunnyVilla)
+            {
+                if (Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == 1231000))
+                {
+                    Client.SendGoalCompletion();
+                }
+            }
+            else if ((CompletionGoal)goal == CompletionGoal.Sorceress2)
+            {
+                if (Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == 1266000))
+                {
+                    Client.SendGoalCompletion();
+                }
+            }
+
         }
         private static async void RunLagTrap()
         {

--- a/source/App.xaml.cs
+++ b/source/App.xaml.cs
@@ -98,11 +98,20 @@ namespace S3AP
             {
                 RunLagTrap();
             }
+            else if (args.Item.Name == "Big Head Mode")
+            {
+                ActivateBigHeadMode();
+            }
+            else if (args.Item.Name == "Turn Spyro Yellow")
+            {
+                TurnSpyroColor(Addresses.SpyroColorYellow);
+            }
         }
         private static void CheckGoalCondition()
         {
             var currentEggs = CalculateCurrentEggs();
             int goal = int.Parse(Client.Options.GetValueOrDefault("goal").ToString());
+            // TODO: Don't hard code IDs.
             if ((CompletionGoal)goal == CompletionGoal.Sorceress1)
             {
                 if (currentEggs >= 100 && Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == 1264000))
@@ -110,9 +119,9 @@ namespace S3AP
                     Client.SendGoalCompletion();
                 }
             }
-            else if ((CompletionGoal)goal == CompletionGoal.SunnyVilla)
+            else if ((CompletionGoal)goal == CompletionGoal.EggForSale)
             {
-                if (Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == 1231000))
+                if (Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == 1257005))
                 {
                     Client.SendGoalCompletion();
                 }
@@ -124,7 +133,13 @@ namespace S3AP
                     Client.SendGoalCompletion();
                 }
             }
-
+            else if ((CompletionGoal)goal == CompletionGoal.SunnyVilla)
+            {
+                if (Client.CurrentSession.Locations.AllLocationsChecked.Any(x => GameLocations.First(y => y.Id == x).Id == 1231000))
+                {
+                    Client.SendGoalCompletion();
+                }
+            }
         }
         private static async void RunLagTrap()
         {
@@ -133,6 +148,18 @@ namespace S3AP
                 lagTrap.Start();
                 await lagTrap.WaitForCompletionAsync();
             }
+        }
+        private static async void ActivateBigHeadMode()
+        {
+            Memory.Write(Addresses.BigHeadMode, (short)(1));
+            // TODO: This crashes on save.  But why?
+            Memory.Write(Addresses.SpyroHeight, (short)(32));
+            Memory.Write(Addresses.SpyroLength, (short)(32));
+            Memory.Write(Addresses.SpyroWidth, (short)(32));
+        }
+        private static async void TurnSpyroColor(short colorEnum)
+        {
+            Memory.Write(Addresses.SpyroColorAddress, colorEnum);
         }
         private static void LogItem(Item item)
         {

--- a/source/App.xaml.cs
+++ b/source/App.xaml.cs
@@ -10,7 +10,6 @@ using Archipelago.MultiClient.Net.MessageLog.Messages;
 using Microsoft.Maui.Devices.Sensors;
 using Newtonsoft.Json;
 using Serilog;
-using System.Runtime.Intrinsics.X86;
 using static S3AP.Models.Enums;
 using Color = Microsoft.Maui.Graphics.Color;
 using Location = Archipelago.Core.Models.Location;
@@ -83,6 +82,7 @@ namespace S3AP
 
         private async void ItemReceived(object? o, ItemReceivedEventArgs args)
         {
+            Log.Logger.Information($"Item Received: {JsonConvert.SerializeObject(args.Item)}");
             if (args.Item.Name == "Egg")
             {
                 var currentEggs = CalculateCurrentEggs();

--- a/source/Helpers.cs
+++ b/source/Helpers.cs
@@ -108,7 +108,7 @@ namespace S3AP
                     // Level Completed (first egg)
                     Location location = new Location()
                     {
-                        Name = level.Name + " Completed",
+                        Name = level.Name + " Complete",
                         Id = baseId + (levelOffset * (level.LevelId - 1)) + level.EggCount,
                         AddressBit = 0,
                         CheckType = LocationCheckType.Bit,

--- a/source/Helpers.cs
+++ b/source/Helpers.cs
@@ -131,6 +131,20 @@ namespace S3AP
                     };
                     locations.Add(location);
                 }
+                if (level.Name.Equals("Midnight Mountain"))
+                {
+                    // Moneybags Chase Completed
+                    Location location = new Location()
+                    {
+                        Name = "Moneybags Chase Complete",
+                        Id = baseId + (levelOffset * (level.LevelId - 1)) + level.EggCount,
+                        AddressBit = 5,
+                        CheckType = LocationCheckType.Bit,
+                        Address = currentAddress,
+                        Category = "Event"
+                    };
+                    locations.Add(location);
+                }
                 for (int i = 0; i < level.EggCount; i++)
                 {
                     // Egg collected
@@ -148,7 +162,7 @@ namespace S3AP
                 }
                 if (includeGems && !level.IsBoss)
                 {
-                    var gemCheckOffset = level.IsHomeworld ? 0 : 1;
+                    var gemCheckOffset = level.IsHomeworld && !level.Name.Equals("Midnight Mountain") ? 0 : 1;
                     Location gemLocation = new Location()
                     {
                         Name = $"{level.Name}: All Gems",

--- a/source/Models/Enums.cs
+++ b/source/Models/Enums.cs
@@ -22,5 +22,12 @@ namespace S3AP.Models
             GettingEgg = 15
 
         }
+
+        public enum CompletionGoal
+        {
+            Sorceress1 = 0,
+            SunnyVilla = 1,
+            Sorceress2 = 2
+        }
     }
 }

--- a/source/Models/Enums.cs
+++ b/source/Models/Enums.cs
@@ -19,7 +19,8 @@ namespace S3AP.Models
             LoadingWorld = 7,
             TitleScreen = 11,
             LoadingHomeworld = 12,
-            GettingEgg = 15
+            GettingEgg = 15,
+            StartingGame = 16
 
         }
 
@@ -27,8 +28,9 @@ namespace S3AP.Models
         {
             Sorceress1 = 0,
             EggForSale = 1,
-            Sorceress2 = 2,
-            SunnyVilla = 3
+            Sorceress2 = 2//,
+            //Test goal for ease of debugging
+            //SunnyVilla = 3
         }
     }
 }

--- a/source/Models/Enums.cs
+++ b/source/Models/Enums.cs
@@ -26,8 +26,9 @@ namespace S3AP.Models
         public enum CompletionGoal
         {
             Sorceress1 = 0,
-            SunnyVilla = 1,
-            Sorceress2 = 2
+            EggForSale = 1,
+            Sorceress2 = 2,
+            SunnyVilla = 3
         }
     }
 }

--- a/source/Models/LevelData.cs
+++ b/source/Models/LevelData.cs
@@ -14,7 +14,8 @@ namespace S3AP.Models
         public bool IsHomeworld { get; set; }
         public bool IsBoss { get; set; }
         public int GemCount { get; set; }
-        public LevelData(string name, int levelId, int eggCount, bool isHomeworld, bool isBoss, int gemCount)
+        public string[] SkillPoints { get; set; }
+        public LevelData(string name, int levelId, int eggCount, bool isHomeworld, bool isBoss, int gemCount, string[] skillPoints)
         {
             Name = name;
             EggCount = eggCount;
@@ -22,6 +23,7 @@ namespace S3AP.Models
             IsHomeworld = isHomeworld;
             IsBoss = isBoss;
             GemCount = gemCount;
+            SkillPoints = skillPoints;
         }
     }
 }

--- a/source/S3AP.csproj
+++ b/source/S3AP.csproj
@@ -21,7 +21,7 @@
     <!-- App Identifier -->
     <ApplicationId>com.arsonassassin.s3ap</ApplicationId>
     <!-- Versions -->
-    <ApplicationDisplayVersion>0.3.0</ApplicationDisplayVersion>
+    <ApplicationDisplayVersion>0.4.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
@@ -47,6 +47,7 @@
     <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Archipelago.Core" Version="0.4.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />

--- a/source/S3AP.csproj
+++ b/source/S3AP.csproj
@@ -47,14 +47,14 @@
     <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Archipelago.Core" Version="0.4.0" />
+    <PackageReference Include="Archipelago.Core" Version="1.0.1" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">
     <PackageReference Include="Archipelago.Core.MauiGUI">
-      <Version>0.0.44</Version>
+      <Version>0.0.45</Version>
     </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Features:

- Added skill points as additional checks [#7](https://github.com/Uroogla/S3AP/issues/7).  Users will need to generate a new template file to use these options.
- Implemented additional goals (Egg for Sale, Sorceress 2).  Users will need to generate a new template file to use these options.
- Added additional filler items and traps, including Big Head Mode and Flat Spyro [#24](https://github.com/Uroogla/S3AP/issues/24), Changing Spyro's color [#23](https://github.com/Uroogla/S3AP/issues/23), Temporary Invincibility, and Healing/Harming/Removing Sparx [#5](https://github.com/Uroogla/S3AP/issues/5).  Users will need to generate a new template file to use these options.
- Users may reload all previously received items by sending a message in the client of `clearSpyroGameState`, closing and reopening the client, and reconnecting.  This is meant to be used to fix item sync issues as a last resort and is experimental.

Bugfixes:

- Fix incorrect egg count on loading into an async archipelago [#20](https://github.com/Uroogla/S3AP/issues/20)
- Fix bug where choosing Duckstation's "reset" option would send many items [#17](https://github.com/Uroogla/S3AP/issues/17)
- Minor logic changes ensuring 150 eggs in the pool and handling an edge case where a seed could become unwinnable if required progression was on a Hunter skateboarding level.
- Fix bug where completing your goal did not correctly inform the server.  It is recommended that you play with the game room having auto-collect off at this time, but auto-release should be safe.