### PR TITLE
Patch bugs in client, async situations, and lag traps

### DIFF
--- a/apworld/spyro3/Items.py
+++ b/apworld/spyro3/Items.py
@@ -267,8 +267,8 @@ def BuildItemPool(multiworld, count, preplaced_eggs, options):
             allowed_trap_items.append(item)
         elif item.name == 'Sparxless Trap' and options.enable_trap_sparxless:
             allowed_trap_items.append(item)
-        elif item.name == 'Lag Trap' and options.enable_trap_lag:
-            allowed_trap_items.append(item)
+        #elif item.name == 'Lag Trap' and options.enable_trap_lag:
+        #    allowed_trap_items.append(item)
 
     if remaining_count > 0 and options.trap_filler_percent.value > 0 and len(allowed_trap_items) == 0:
         raise OptionError(f"Trap percentage is set to {options.trap_filler_percent.value}, but none have been turned on.")

--- a/apworld/spyro3/Options.py
+++ b/apworld/spyro3/Options.py
@@ -174,9 +174,9 @@ class EnableTrapSparxless(Toggle):
     """Allows filler items to include removing Sparx."""
     display_name = "Enable Sparxless Trap"
 
-class EnableTrapLag(Toggle):
-    """Allows filler items to include traps that simulate lag in Duckstation."""
-    display_name = "Enable Lag Trap"
+#class EnableTrapLag(Toggle):
+#    """Allows filler items to include traps that simulate lag in Duckstation."""
+#    display_name = "Enable Lag Trap"
 
 class EnableProgressiveSparxHealth(Choice):
     """Start the game with lower max health and add items to the pool to increase your max health.
@@ -434,7 +434,7 @@ class Spyro3Option(PerGameCommonOptions):
     trap_filler_percent: TrapFillerPercent
     enable_trap_damage_sparx: EnableTrapDamageSparx
     enable_trap_sparxless: EnableTrapSparxless
-    enable_trap_lag: EnableTrapLag
+    #enable_trap_lag: EnableTrapLag
     enable_progressive_sparx_health: EnableProgressiveSparxHealth
     enable_progressive_sparx_logic: ProgressiveSparxHealthLogic
     zoe_gives_hints: ZoeGivesHints

--- a/apworld/spyro3/__init__.py
+++ b/apworld/spyro3/__init__.py
@@ -1240,7 +1240,7 @@ class Spyro3World(World):
                 "trap_filler_percent": self.options.trap_filler_percent.value,
                 "enable_trap_damage_sparx": self.options.enable_trap_damage_sparx.value,
                 "enable_trap_sparxless": self.options.enable_trap_sparxless.value,
-                "enable_trap_lag": self.options.enable_trap_lag.value,
+                #"enable_trap_lag": self.options.enable_trap_lag.value,
                 "enable_progressive_sparx_health": self.options.enable_progressive_sparx_health.value,
                 "enable_progressive_sparx_logic": self.options.enable_progressive_sparx_logic.value,
                 "zoe_gives_hints": self.options.zoe_gives_hints.value,

--- a/source/S3AP/Helpers.cs
+++ b/source/S3AP/Helpers.cs
@@ -366,7 +366,9 @@ namespace S3AP
                     int subarea = 0;
                     if (
                         level.LifeBottles[i] == Addresses.BambooBentleyLifeBottleAddress ||
-                        level.LifeBottles[i] == Addresses.FireworksAgentLifeBottleAddress
+                        level.LifeBottles[i] == Addresses.FireworksAgentLifeBottleAddress ||
+                        level.LifeBottles[i] == Addresses.FleetSkateboardingLifeBottleAddress ||
+                        level.LifeBottles[i] == Addresses.MoltenLifeBottleAddress
                     )
                     {
                         subarea = 2;


### PR DESCRIPTION
Bug Fixes:
- Removes lag trap, which crashed some players' Duckstation in a way that released checks.
- Patch issue where disconnecting removed all world keys and some Sparx upgrades from the player's inventory.
- Patch issue where Molten Thieves and Lost Fleet Skateboarding life bottles would not trigger.
- Attempt to patch issue where reconnecting to server without closing client first could cause unexpected behavior and crashes.
- Attempt to patch issue where processing too many cosmetic changes at once could crash the client, possibly due to concurrency issues.